### PR TITLE
feat: easy access to used weight in Binance headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Allow easy access to the `used_weight` header in a response by calling `#used_weight(interval)`
+
 ## [1.1.0]
 ### Added
 - `order_book_depth` (`/api/v3/depth`) to get a snapshot of the order book

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     binance_client (1.1.0)
       activesupport
-      api_client_base
+      api_client_base (~> 1.11)
       typhoeus
 
 GEM
@@ -17,7 +17,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    api_client_base (1.10.0)
+    api_client_base (1.11.0)
       activesupport (>= 3.0)
       gem_config (>= 0.3.1)
       virtus (>= 1.0)
@@ -40,7 +40,7 @@ GEM
     ffi (1.15.4)
     gem_config (0.3.2)
     hashdiff (1.0.1)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     method_source (1.0.0)
@@ -84,7 +84,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
@@ -99,4 +99,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.24
+   2.2.28

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ client.order_book_depth(symbol: "BTCUSDT", limit: 100)
 ## Responses
 The default representation of response data is a JSON hash
 
+## Hooks
+You can set a hook to do application-specific things per request. This is useful when monitoring the rate limits:
+
+```ruby
+BinanceClient.after_request = DoSomethingAfterBinanceRequest
+```
+
+What you assign can be a proc -- it just needs to respond to `call` and accept the `BinanceClient` response object:
+
+```ruby
+class DoSomethingAfterBinanceRequest
+
+  def self.call(response)
+    one_minute_weight = response.used_weight("1m")
+    if one_minute_weight > 1200
+      Rails.logger.info "Looks like we've hit the request limit!"
+    end
+  end
+
+end
+```
 
 ## Development
 Edit the `config.yml.sample` with your own credentials for testing

--- a/binance_client.gemspec
+++ b/binance_client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "api_client_base"
+  spec.add_dependency "api_client_base", "~> 1.11"
   spec.add_dependency "activesupport"
   spec.add_dependency "typhoeus"
 

--- a/lib/binance_client/responses/base_response.rb
+++ b/lib/binance_client/responses/base_response.rb
@@ -2,12 +2,19 @@ module BinanceClient
   class BaseResponse
     include APIClientBase::Response.module
 
-    attribute :body, Object, default: :default_body
+    attribute :body, Object, lazy: true, default: :default_body
+
+    def used_weight(interval)
+      val = header("X-MBX-USED-WEIGHT-#{interval}")
+      return nil if val.nil?
+      val.to_i
+    end
 
     private
 
     def default_body
       JSON.parse(raw_response.body)
     end
+
   end
 end

--- a/spec/lib/models/base_response_spec.rb
+++ b/spec/lib/models/base_response_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+module BinanceClient
+  RSpec.describe BaseResponse do
+
+    describe "#used_weight(interval)" do
+      context "used weight exists" do
+        let(:raw_headers) do
+          {
+            "X-Mbx-Used-Weight-1m" => '1',
+          }
+        end
+        let(:raw_response) do
+          instance_double Typhoeus::Response, headers: raw_headers
+        end
+        let(:response) do
+          described_class.new(raw_response: raw_response)
+        end
+
+        it "returns the used weight of the interval as an Integer" do
+          expect(response.used_weight("1m")).to eq 1
+        end
+      end
+
+      context "used weight does not exist" do
+        let(:raw_headers) do
+          {
+            "X-Mbx-Used-Weight-1m" => '1',
+          }
+        end
+        let(:raw_response) do
+          instance_double Typhoeus::Response, headers: raw_headers
+        end
+        let(:response) do
+          described_class.new(raw_response: raw_response)
+        end
+
+        it "returns the used weight of the interval as an Integer" do
+          expect(response.used_weight("1h")).to be_nil
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This upgrades api_client_base to 1.11 which also adds [hook functionality](https://github.com/bloom-solutions/api_client_base-ruby/commit/28c72bd15f3ea110975e62b8fb693916f2359aeb)