### PR TITLE
feat: add `#used_weights` to the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Remove `used_weight` from responses
+
+### Added
+- `used_weights` to responses
+
 ## [1.4.0] - 2021-12-09
 ### Added
 - Add factories for use in app development

--- a/lib/binance_client/responses/base_response.rb
+++ b/lib/binance_client/responses/base_response.rb
@@ -4,10 +4,12 @@ module BinanceClient
 
     attribute :body, Object, lazy: true, default: :default_body
 
-    def used_weight(interval)
-      val = header("X-MBX-USED-WEIGHT-#{interval}")
-      return nil if val.nil?
-      val.to_i
+    def used_weights
+      @used_weights ||= headers.each_with_object({}) do |(key, value), hash|
+        next if not key.include?("USED")
+        next if not key.include?("WEIGHT")
+        hash[key] = value
+      end
     end
 
     def message

--- a/spec/lib/models/base_response_spec.rb
+++ b/spec/lib/models/base_response_spec.rb
@@ -3,11 +3,14 @@ require 'spec_helper'
 module BinanceClient
   RSpec.describe BaseResponse do
 
-    describe "#used_weight(interval)" do
+    describe "#used_weights" do
       context "used weight exists" do
         let(:raw_headers) do
           {
+            "X-Mbx-Used-Weight-1d" => '100',
             "X-Mbx-Used-Weight-1m" => '1',
+            "X-SAPI-USED-IP-WEIGHT-1M" => "10",
+            "Another-Header" => "ABC",
           }
         end
         let(:raw_response) do
@@ -17,26 +20,12 @@ module BinanceClient
           described_class.new(raw_response: raw_response)
         end
 
-        it "returns the used weight of the interval as an Integer" do
-          expect(response.used_weight("1m")).to eq 1
-        end
-      end
-
-      context "used weight does not exist" do
-        let(:raw_headers) do
-          {
-            "X-Mbx-Used-Weight-1m" => '1',
-          }
-        end
-        let(:raw_response) do
-          instance_double Typhoeus::Response, headers: raw_headers
-        end
-        let(:response) do
-          described_class.new(raw_response: raw_response)
-        end
-
-        it "returns the used weight of the interval as an Integer" do
-          expect(response.used_weight("1h")).to be_nil
+        it "returns all the used weights" do
+          expect(response.used_weights).to eq({
+            "X-MBX-USED-WEIGHT-1D" => '100',
+            "X-MBX-USED-WEIGHT-1M" => '1',
+            "X-SAPI-USED-IP-WEIGHT-1M" => "10",
+          })
         end
       end
     end


### PR DESCRIPTION
Easily fetch the used weights, including those that match "X-SAPI-USED-IP-WEIGHT".

Remove `#used_weight` call since it assumed too much; instead, show all
and let the apps fetch them all