### PR TITLE
feat: include optional network when getting deposit address

### DIFF
--- a/lib/binance_client/client.rb
+++ b/lib/binance_client/client.rb
@@ -10,7 +10,7 @@ module BinanceClient
     api_action :book_ticker
     api_action :order_book_depth
     api_action :sub_account_assets, args: [:email]
-    api_action :sub_account_deposit_address, args: [:email, :coin]
+    api_action :sub_account_deposit_address
     api_action :sub_account_deposit_history
 
     attribute :host

--- a/spec/acceptance/sub_account_deposit_address_spec.rb
+++ b/spec/acceptance/sub_account_deposit_address_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "#sub_account_deposit_address", vcr: {record: :once} do
 
   it "returns the account's deposit address" do
     response =
-      client.sub_account_deposit_address(CONFIG[:sub_account_email], "BTC")
+      client.sub_account_deposit_address(email: CONFIG[:sub_account_email], coin: "BTC", network: "BNB")
     expect(response).to be_success
 
     deposit_address = response.deposit_address
@@ -20,7 +20,11 @@ RSpec.describe "#sub_account_deposit_address", vcr: {record: :once} do
 
     aggregate_failures do
       expect(deposit_address.address).to be_a String
+      expect(deposit_address.address).to be_present
       expect(deposit_address.coin).to be_a String
+      expect(deposit_address.coin).to be_present
+      expect(deposit_address.tag).to be_a String
+      expect(deposit_address.tag).to be_present
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/_sub_account_deposit_address/returns_the_account_s_deposit_address.yml
+++ b/spec/fixtures/vcr_cassettes/_sub_account_deposit_address/returns_the_account_s_deposit_address.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "[host]/sapi/v1/capital/deposit/subAddress?coin=BTC&email=[sub_account_email]&recvWindow=60000&signature=9f13b8274abc9d73115443501168db74a01c49e8424d3613f890b8e218850e92&timestamp=1640668070176"
+    uri: "[host]/sapi/v1/capital/deposit/subAddress?coin=BTC&email=[sub_account_email]&network=BNB&recvWindow=60000&signature=f5735ed0cb3a2056df616490bfd42a7144fac8607fe822b68456733b80dc637e&timestamp=1646627132960"
     body:
       encoding: US-ASCII
       string: ''
@@ -23,9 +23,9 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '152'
+      - '175'
       Date:
-      - Tue, 28 Dec 2021 05:07:50 GMT
+      - Mon, 07 Mar 2022 04:25:33 GMT
       Server:
       - nginx
       X-Sapi-Used-Ip-Weight-1m:
@@ -57,13 +57,13 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ef580dc211b3c53b8a241527f1dd5f63.cloudfront.net (CloudFront)
+      - 1.1 101fe44f3abacff135b2a73264d75b1e.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - MNL50-C1
+      - SIN5-C1
       X-Amz-Cf-Id:
-      - MysCOhl4Io6RP8mT5pEl3AUreQItxXdn7j7Ruv5JmsmjYulePGIdSQ==
+      - jz22CKikb48V4TC_gQn3XMyNegoCvAcUnvMgkvb2X02SIHaRl3fn0w==
     body:
       encoding: ASCII-8BIT
-      string: '{"coin":"BTC","address":"1C1Gfnfrxgyv5QsSPxoZMpfybBjbXsvPRA","tag":"","url":"https://blockchair.com/bitcoin/address/1C1Gfnfrxgyv5QsSPxoZMpfybBjbXsvPRA"}'
-  recorded_at: Tue, 28 Dec 2021 05:07:50 GMT
+      string: '{"coin":"BTC","address":"bnb136ns6lfw4zs5hg4n85vdthaad7hq5m4gtkgf23","tag":"100159781","url":"https://explorer.binance.org/address/bnb136ns6lfw4zs5hg4n85vdthaad7hq5m4gtkgf23"}'
+  recorded_at: Mon, 07 Mar 2022 04:25:33 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
This PR now allows the `network` option to be passed in the API call to return the deposit address for a specific network. Previously, it would always just return the default network since it was never provided. Since we are changing how this endpoint is called (previously just the arguments to keyword arguments), we will need to bump up this version,