### PR TITLE
feat: `all_orders` request and `Order` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0] - 2022-05-20
+### Added
+- `#all_orders`
+
 ## [5.1.0] - 2022-04-22
 ### Added
 - `#ping`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    binance_client (5.1.0)
+    binance_client (5.2.0)
       activesupport
       api_client_base (~> 1.11)
       typhoeus

--- a/lib/binance_client/client.rb
+++ b/lib/binance_client/client.rb
@@ -23,6 +23,7 @@ module BinanceClient
     api_action :create_order
     api_action :withdraw
     api_action :ping
+    api_action :all_orders, args: [:symbol, :start_time]
 
     attribute :host
     attribute :api_key

--- a/lib/binance_client/models/order.rb
+++ b/lib/binance_client/models/order.rb
@@ -1,0 +1,23 @@
+module BinanceClient
+  class Order
+    attr_reader :symbol
+    attr_reader :executed_quantity
+    attr_reader :cummulative_quote_quantity
+    attr_reader :order_id
+    attr_reader :side
+
+    def initialize(
+      symbol:,
+      executed_quantity:,
+      cummulative_quote_quantity:,
+      order_id:,
+      side:
+    )
+      @symbol = symbol
+      @executed_quantity = executed_quantity
+      @cummulative_quote_quantity = cummulative_quote_quantity
+      @order_id = order_id
+      @side = side
+    end
+  end
+end

--- a/lib/binance_client/requests/all_orders_request.rb
+++ b/lib/binance_client/requests/all_orders_request.rb
@@ -1,0 +1,17 @@
+module BinanceClient
+  class AllOrdersRequest < AuthenticatedBaseRequest
+    attribute :symbol, String
+    attribute :start_time, Integer
+
+    def path
+      "/api/v3/allOrders"
+    end
+
+    def params_without_signature
+      {
+        symbol: symbol,
+        startTime: start_time
+      }
+    end
+  end
+end

--- a/lib/binance_client/responses/all_orders_response.rb
+++ b/lib/binance_client/responses/all_orders_response.rb
@@ -1,0 +1,15 @@
+module BinanceClient
+  class AllOrdersResponse < BaseResponse
+    def orders
+      body.map do |hash|
+        Order.new({
+          symbol: hash["symbol"],
+          executed_quantity: hash["executedQty"],
+          cummulative_quote_quantity: hash["cummulativeQuoteQty"],
+          order_id: hash["orderId"],
+          side: hash["side"],
+        })
+      end
+    end
+  end
+end

--- a/lib/binance_client/version.rb
+++ b/lib/binance_client/version.rb
@@ -1,3 +1,3 @@
 module BinanceClient
-  VERSION = "5.1.0"
+  VERSION = "5.2.0"
 end

--- a/spec/acceptance/all_orders_spec.rb
+++ b/spec/acceptance/all_orders_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe "#all_orders", vcr: { record: :once } do
+  let(:client) do
+    BinanceClient.new(
+      host: CONFIG[:host],
+      api_key: CONFIG[:sub_account_api_key],
+      api_secret: CONFIG[:sub_account_api_secret]
+    )
+  end
+
+  it "retrieves all orders within a timeframe" do
+    response = client.all_orders("ETHUSDT", "1651298308000")
+
+    expect(response).to be_success
+  end
+end

--- a/spec/acceptance/all_orders_spec.rb
+++ b/spec/acceptance/all_orders_spec.rb
@@ -13,5 +13,18 @@ RSpec.describe "#all_orders", vcr: { record: :once } do
     response = client.all_orders("ETHUSDT", "1651298308000")
 
     expect(response).to be_success
+    
+    orders = response.orders
+    order = orders.first
+    
+    aggregate_failures do
+      expect(orders).to be_present
+      expect(orders).to_not be_empty
+      expect(order.order_id).to be_a(Integer)
+      expect(order.executed_quantity).to be_a(String)
+      expect(order.cummulative_quote_quantity).to be_a(String)
+      expect(order.symbol).to be_a(String)
+      expect(order.symbol).to be_a(String)
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/_all_orders/retrieves_all_orders_within_a_timeframe.yml
+++ b/spec/fixtures/vcr_cassettes/_all_orders/retrieves_all_orders_within_a_timeframe.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "[host]/api/v3/allOrders?recvWindow=60000&signature=8a07b5465420483da428967c879d41315ebc6e4eece62a37ea4c8e0b99184424&startTime=1651298308000&symbol=ETHUSDT&timestamp=1653026338449"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Content-Type:
+      - application/json
+      X-Mbx-Apikey:
+      - gqaPuYPGwGhA5y7MtELQuir0Ua0E6gITtAEis7JQV8ABJbJzsBT5ZLjzjQyxwRAf
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '440'
+      Date:
+      - Fri, 20 May 2022 05:58:58 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Mbx-Uuid:
+      - d0772efd-3c92-4a87-b18f-89bd2bf82372
+      X-Mbx-Used-Weight:
+      - '30'
+      X-Mbx-Used-Weight-1m:
+      - '30'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, OPTIONS
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e8cd61c9b2a785e4fc8167b0177016b8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SIN2-C1
+      X-Amz-Cf-Id:
+      - 32GgHwVkd4NzR5Yqh63_vmax7smKjASAaNrA-OVN9uA5uGHt0I0zkw==
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"symbol":"ETHUSDT","orderId":8848559626,"orderListId":-1,"clientOrderId":"web_5a1ebca8b224446993b0ca14abef4cf5","price":"0.00000000","origQty":"1.20000000","executedQty":"1.20000000","cummulativeQuoteQty":"2769.10800000","status":"FILLED","timeInForce":"GTC","type":"MARKET","side":"BUY","stopPrice":"0.00000000","icebergQty":"0.00000000","time":1652148725960,"updateTime":1652148725960,"isWorking":true,"origQuoteOrderQty":"0.00000000"}]'
+  recorded_at: Fri, 20 May 2022 05:58:58 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/models/order_spec.rb
+++ b/spec/lib/models/order_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+module BinanceClient
+  RSpec.describe Order do
+    subject(:order) do
+      described_class.new({
+        symbol: "ETHUSDT",
+        executed_quantity: "1.20000000",
+        cummulative_quote_quantity: "2769.10800000",
+        order_id: 8848559626,
+        side: "BUY",
+      })
+    end
+
+    its(:symbol) { is_expected.to eq "ETHUSDT" }
+    its(:executed_quantity) { is_expected.to eq "1.20000000" }
+    its(:cummulative_quote_quantity) { is_expected.to eq "2769.10800000" }
+    its(:order_id) { is_expected.to eq 8848559626 }
+    its(:side) { is_expected.to eq "BUY" }
+  end
+end

--- a/spec/lib/requests/all_orders_request_spec.rb
+++ b/spec/lib/requests/all_orders_request_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module BinanceClient
+  RSpec.describe AllOrdersRequest do
+
+    describe "#params" do
+      context "with all options" do
+        let(:request) do
+          described_class.new(
+            api_key: CONFIG[:api_key],
+            api_secret: CONFIG[:api_secret],
+
+            symbol: "ETHUSDT",
+            start_time: 1653013822614,
+          )
+        end
+        subject(:params) { request.params }
+
+        it "builds parameters" do
+          aggregate_failures do
+            expect(params).to include("symbol=ETHUSDT")
+            expect(params).to include("startTime=1653013822614")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/responses/all_orders_response_spec.rb
+++ b/spec/lib/responses/all_orders_response_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module BinanceClient
+  RSpec.describe AllOrdersResponse do
+
+    let(:body) do
+      [
+        {
+          "symbol"=>"ETHUSDT",
+          "orderId"=>8848559626,
+          "orderListId"=>-1,
+          "clientOrderId"=>"web_5a1ebca8b224446993b0ca14abef4cf5",
+          "price"=>"0.00000000",
+          "origQty"=>"1.20000000",
+          "executedQty"=>"1.20000000",
+          "cummulativeQuoteQty"=>"2769.10800000",
+          "status"=>"FILLED",
+          "timeInForce"=>"GTC",
+          "type"=>"MARKET",
+          "side"=>"BUY",
+          "stopPrice"=>"0.00000000",
+          "icebergQty"=>"0.00000000",
+          "time"=>1652148725960,
+          "updateTime"=>1652148725960,
+          "isWorking"=>true,
+          "origQuoteOrderQty"=>"0.00000000",
+        }
+      ]
+    end
+
+    subject(:order) do
+      described_class.new(body: body).orders.first
+    end
+
+    its(:symbol) { is_expected.to eq "ETHUSDT" }
+    its(:executed_quantity) { is_expected.to eq "1.20000000" }
+    its(:cummulative_quote_quantity) { is_expected.to eq "2769.10800000" }
+    its(:order_id) { is_expected.to eq 8848559626 }
+    its(:side) { is_expected.to eq "BUY" }
+
+  end
+end


### PR DESCRIPTION
Added the `all_orders` request for usage in an app. This returns an array of `BinanceClient::Order` where attributes such as `side`, `order_id`, `executed_quantity` and `cummulative_quote_quantity` can be accessed.